### PR TITLE
Update manifest.json with version tag

### DIFF
--- a/custom_components/google_fit/manifest.json
+++ b/custom_components/google_fit/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "google_fit",
   "name": "Google Fit",
+  "version": "1.1.4",
   "dependencies": [],
   "codeowners": ["@vmanuel"],
   "requirements": ["google-api-python-client==1.6.4","oauth2client==4.0.0","httplib2"]


### PR DESCRIPTION
Update manifest.json to use version tag, which is a new requirement for custom components in Home Assistant.